### PR TITLE
URL decode incoming queries

### DIFF
--- a/hypocloid/Cargo.lock
+++ b/hypocloid/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "notmuch 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-ini 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/hypocloid/Cargo.toml
+++ b/hypocloid/Cargo.toml
@@ -18,6 +18,7 @@ serde = "*"
 serde_derive = "*"
 serde_json = "*"
 warp = "*"
+percent-encoding = "2.1.0"
 
 [dependencies.tokio]
 features = ["full"]

--- a/hypocloid/src/threads.rs
+++ b/hypocloid/src/threads.rs
@@ -7,6 +7,7 @@ use serde_derive::Serialize;
 use std::convert::Infallible;
 use std::sync::Arc;
 use warp::{http::Response, Filter};
+use percent_encoding::{percent_decode_str};
 
 #[derive(Debug, Serialize)]
 pub struct Thread {
@@ -26,8 +27,9 @@ impl Threads {
     pub fn new(db: String, q: String) -> Threads {
         let db = Arc::new(notmuch::Database::open(&db, notmuch::DatabaseMode::ReadOnly).unwrap());
 
-        debug!("threads query: {}..", q);
-        let query = Arc::new(notmuch::Query::create(db.clone(), &q).unwrap());
+        let formatted = &percent_decode_str(&q).decode_utf8();
+        debug!("threads query: {}..", formatted.as_ref().unwrap());
+        let query = Arc::new(notmuch::Query::create(db.clone(), &formatted.as_ref().unwrap()).unwrap());
 
         let threads =
             <notmuch::Query<'static> as notmuch::QueryExt>::search_threads(query.clone()).unwrap();


### PR DESCRIPTION
This allows the `/threads` endpoint to process queries like `tag:inbox and folder:sync/INBOX and not tag:spam` using a URL like `/threads/tag:inbox%20and%20folder:sync%2FINBOX%20and%20not%20tag:spam`