### PR TITLE
add a POST method to /messages/* that allows changing tags

### DIFF
--- a/hypocloid/Cargo.toml
+++ b/hypocloid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Gaute Hope <eg@gaute.vetsj.com>"]
-edition = "2018"
+edition = "2021"
 name = "hypocloid"
 version = "0.1.0"
 [dependencies]

--- a/hypocloid/src/main.rs
+++ b/hypocloid/src/main.rs
@@ -18,7 +18,8 @@ use state::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::Builder::from_env(Env::default().default_filter_or("hypocloid=debug,warp=info")).init();
+    env_logger::Builder::from_env(Env::default().default_filter_or("hypocloid=debug,warp=info"))
+        .init();
     info!("hypocloid!");
     info!("notmuch config: {}", notmuch_config().to_str().unwrap());
 

--- a/hypocloid/src/main.rs
+++ b/hypocloid/src/main.rs
@@ -10,10 +10,10 @@ use warp::Filter;
 
 /* internal modules */
 mod messages;
+mod models;
 mod state;
 mod tags;
 mod threads;
-mod models;
 
 use state::*;
 

--- a/hypocloid/src/main.rs
+++ b/hypocloid/src/main.rs
@@ -13,6 +13,7 @@ mod messages;
 mod state;
 mod tags;
 mod threads;
+mod models;
 
 use state::*;
 

--- a/hypocloid/src/messages.rs
+++ b/hypocloid/src/messages.rs
@@ -6,10 +6,7 @@ use warp::{http::Response, reply::Reply, Filter};
 pub mod handlers {
     use super::*;
 
-    pub async fn query(
-        query: String,
-        _: Arc<HypoState>,
-    ) -> Result<impl warp::Reply, Infallible> {
+    pub async fn query(query: String, _: Arc<HypoState>) -> Result<impl warp::Reply, Infallible> {
         use std::process::Command;
         debug!("messages: {}", query);
 
@@ -31,7 +28,8 @@ pub mod handlers {
         match messages {
             Ok(messages) => Ok(Response::builder()
                 .header("Content-Type", "application/json")
-                .body(messages.stdout).into_response()),
+                .body(messages.stdout)
+                .into_response()),
             Err(_) => Ok(warp::http::StatusCode::BAD_REQUEST.into_response()),
         }
     }

--- a/hypocloid/src/messages.rs
+++ b/hypocloid/src/messages.rs
@@ -3,6 +3,8 @@ use std::convert::Infallible;
 use std::sync::Arc;
 use warp::{http::Response, reply::Reply, Filter};
 
+use crate::models::TagRequest;
+
 pub mod handlers {
     use super::*;
 
@@ -34,30 +36,55 @@ pub mod handlers {
         }
     }
 
-    pub async fn tag(
-        query: String,
-        command: bytes::Bytes,
-        _: Arc<HypoState>,
-    ) -> Result<impl warp::Reply, Infallible> {
-        use std::process::Command;
-        debug!("changing tags on {}: {:?}", query, command);
-
-        let data = std::str::from_utf8(&command).unwrap();
-
-        let messages = Command::new("notmuch").arg("tag").arg(data).arg(query).output();
-
-        match messages {
-            Ok(messages) => Ok(Response::builder()
-                .header("Content-Type", "application/json")
-                .body(messages.stdout)
-                .into_response()),
-            Err(_) => Ok(warp::http::StatusCode::BAD_REQUEST.into_response()),
-        }
-    }
+    
 
     pub async fn all(state: Arc<HypoState>) -> Result<impl warp::Reply, Infallible> {
         query("".to_string(), state).await
     }
+
+
+    pub fn tag(
+        query: String,
+        command: TagRequest,
+        state: Arc<HypoState>,
+    ) -> impl warp::Reply {
+        debug!("changing tags on {}: {:?}", query, command);
+
+        let nmdb = state
+            .notmuch_config
+            .get_from(Some("database"), "path")
+            .unwrap();
+
+        let db =
+            notmuch::Database::open(&String::from(nmdb), notmuch::DatabaseMode::ReadWrite).unwrap();
+        let dbquery =  notmuch::Query::create(db, &("id:".to_owned()+&query)).unwrap();
+
+        let messages =
+            <notmuch::Query<'static> as notmuch::QueryExt>::search_messages(dbquery).unwrap();
+
+        for mh in messages {
+            match command.add {
+                Some(ref x) => {
+                    for tag in x {
+                        mh.add_tag(tag).unwrap();
+                    }
+                }
+                None => debug!("no tags to add"),
+            }
+
+            match command.remove {
+                Some(ref x) => {
+                    for tag in x {
+                        mh.remove_tag(tag).unwrap();
+                    }
+                }
+                None => debug!("no tags to remove"),
+            }
+        }
+
+        warp::http::StatusCode::NO_CONTENT
+    }
+
 }
 
 pub mod filters {
@@ -92,10 +119,11 @@ pub mod filters {
     pub fn tag(
         state: Arc<HypoState>,
     ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-        warp::path!("messages" / String)
+        warp::path!("messages" / String / "tag")
             .and(warp::post())
-            .and(warp::body::bytes())
+            .and(warp::body::json())
             .and(with_state(state))
-            .and_then(handlers::tag)
+            .map(handlers::tag)
     }
 }
+

--- a/hypocloid/src/messages.rs
+++ b/hypocloid/src/messages.rs
@@ -56,6 +56,7 @@ pub mod handlers {
             <notmuch::Query<'static> as notmuch::QueryExt>::search_messages(dbquery).unwrap();
 
         for mh in messages {
+            debug!("Message ID: {:?}", mh.id());
             match command.add {
                 Some(ref x) => {
                     for tag in x {

--- a/hypocloid/src/messages.rs
+++ b/hypocloid/src/messages.rs
@@ -44,7 +44,6 @@ pub mod handlers {
         use std::process::Command;
         debug!("changing tags on {}: {:?}", query, command);
 
-        // query("".to_string(), state).await
         let data = std::str::from_utf8(&command).unwrap();
 
         let messages = Command::new("notmuch").arg("tag").arg(data).arg(query).output();

--- a/hypocloid/src/messages.rs
+++ b/hypocloid/src/messages.rs
@@ -57,7 +57,7 @@ pub mod handlers {
 
         let db =
             notmuch::Database::open(&String::from(nmdb), notmuch::DatabaseMode::ReadWrite).unwrap();
-        let dbquery =  notmuch::Query::create(db, &("id:".to_owned()+&query)).unwrap();
+        let dbquery =  notmuch::Query::create(db, &query).unwrap();
 
         let messages =
             <notmuch::Query<'static> as notmuch::QueryExt>::search_messages(dbquery).unwrap();

--- a/hypocloid/src/messages.rs
+++ b/hypocloid/src/messages.rs
@@ -36,18 +36,11 @@ pub mod handlers {
         }
     }
 
-    
-
     pub async fn all(state: Arc<HypoState>) -> Result<impl warp::Reply, Infallible> {
         query("".to_string(), state).await
     }
 
-
-    pub fn tag(
-        query: String,
-        command: TagRequest,
-        state: Arc<HypoState>,
-    ) -> impl warp::Reply {
+    pub fn tag(query: String, command: TagRequest, state: Arc<HypoState>) -> impl warp::Reply {
         debug!("changing tags on {}: {:?}", query, command);
 
         let nmdb = state
@@ -57,7 +50,7 @@ pub mod handlers {
 
         let db =
             notmuch::Database::open(&String::from(nmdb), notmuch::DatabaseMode::ReadWrite).unwrap();
-        let dbquery =  notmuch::Query::create(db, &query).unwrap();
+        let dbquery = notmuch::Query::create(db, &query).unwrap();
 
         let messages =
             <notmuch::Query<'static> as notmuch::QueryExt>::search_messages(dbquery).unwrap();
@@ -84,7 +77,6 @@ pub mod handlers {
 
         warp::http::StatusCode::NO_CONTENT
     }
-
 }
 
 pub mod filters {
@@ -126,4 +118,3 @@ pub mod filters {
             .map(handlers::tag)
     }
 }
-

--- a/hypocloid/src/models.rs
+++ b/hypocloid/src/models.rs
@@ -1,0 +1,9 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct TagRequest {
+    pub add: Option<Vec<String>>,
+    pub remove: Option<Vec<String>>,
+}
+
+

--- a/hypocloid/src/models.rs
+++ b/hypocloid/src/models.rs
@@ -5,5 +5,3 @@ pub struct TagRequest {
     pub add: Option<Vec<String>>,
     pub remove: Option<Vec<String>>,
 }
-
-

--- a/hypocloid/src/tags.rs
+++ b/hypocloid/src/tags.rs
@@ -15,7 +15,9 @@ pub mod handlers {
             .unwrap();
 
         let db = Arc::new(notmuch::Database::open(&db, notmuch::DatabaseMode::ReadOnly).unwrap());
-        Ok(warp::reply::json(&db.all_tags().unwrap().collect::<Vec<String>>()))
+        Ok(warp::reply::json(
+            &db.all_tags().unwrap().collect::<Vec<String>>(),
+        ))
     }
 }
 

--- a/hypocloid/src/threads.rs
+++ b/hypocloid/src/threads.rs
@@ -3,10 +3,11 @@ use bytes::Bytes;
 use futures::stream;
 use hyper::Body;
 use percent_encoding::percent_decode_str;
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::Serialize;
 use std::convert::Infallible;
 use std::sync::Arc;
 use warp::{http::Response, Filter};
+use crate::models::TagRequest;
 
 #[derive(Debug, Serialize)]
 pub struct Thread {
@@ -19,13 +20,6 @@ pub struct Thread {
     unread: bool,
     tags: Vec<String>,
 }
-
-#[derive(Deserialize, Debug)]
-pub struct TagRequest {
-    add: Option<Vec<String>>,
-    remove: Option<Vec<String>>,
-}
-
 pub struct Threads(notmuch::Threads<'static, 'static>);
 
 impl Threads {

--- a/hypocloid/src/threads.rs
+++ b/hypocloid/src/threads.rs
@@ -1,3 +1,4 @@
+use crate::models::TagRequest;
 use crate::state::{filters::with_state, HypoState};
 use bytes::Bytes;
 use futures::stream;
@@ -7,7 +8,6 @@ use serde_derive::Serialize;
 use std::convert::Infallible;
 use std::sync::Arc;
 use warp::{http::Response, Filter};
-use crate::models::TagRequest;
 
 #[derive(Debug, Serialize)]
 pub struct Thread {
@@ -86,11 +86,7 @@ pub mod handlers {
         query("".to_string(), state).await
     }
 
-    pub fn tag(
-        query: String,
-        command: TagRequest,
-        state: Arc<HypoState>,
-    ) -> impl warp::Reply {
+    pub fn tag(query: String, command: TagRequest, state: Arc<HypoState>) -> impl warp::Reply {
         debug!("changing tags on {}: {:?}", query, command);
 
         let nmdb = state

--- a/hypocloid/src/threads.rs
+++ b/hypocloid/src/threads.rs
@@ -27,9 +27,10 @@ impl Threads {
         let db = Arc::new(notmuch::Database::open(&db, notmuch::DatabaseMode::ReadOnly).unwrap());
 
         let formatted = &percent_decode_str(&q).decode_utf8();
+
         debug!("threads query: {}..", formatted.as_ref().unwrap());
         let query =
-            Arc::new(notmuch::Query::create(db.clone(), &formatted.as_ref().unwrap()).unwrap());
+            Arc::new(notmuch::Query::create(db.clone(), &("thread:".to_owned()+&formatted.as_ref().unwrap())).unwrap());
 
         let threads =
             <notmuch::Query<'static> as notmuch::QueryExt>::search_threads(query.clone()).unwrap();

--- a/hypocloid/src/threads.rs
+++ b/hypocloid/src/threads.rs
@@ -97,7 +97,6 @@ pub mod handlers {
         let db =
             notmuch::Database::open(&String::from(nmdb), notmuch::DatabaseMode::ReadWrite).unwrap();
 
-        // let query = db.create_query(&query).unwrap();
         let query = notmuch::Query::create(db, &query).unwrap();
         let threads =
             <notmuch::Query<'static> as notmuch::QueryExt>::search_threads(query).unwrap();

--- a/hypocloid/src/threads.rs
+++ b/hypocloid/src/threads.rs
@@ -103,12 +103,8 @@ pub mod handlers {
             <notmuch::Query<'static> as notmuch::QueryExt>::search_threads(query).unwrap();
 
         for th in threads {
-            debug!("THREAD ID: {:?}", th.id());
-            // let query = db.create_query(&("thread:".to_owned() + th.id())).unwrap();
-            let query = notmuch::Query::create(db, &("thread:".to_owned() + th.id())).unwrap();
-            let messages =
-                <notmuch::Query<'static> as notmuch::QueryExt>::search_messages(query).unwrap();
-            for mh in messages {
+            debug!("Thread ID: {:?}", th.id());
+            for mh in th.messages() {
                 debug!("Message ID: {:?}", mh.id());
                 match command.add {
                     Some(ref x) => {

--- a/hypocloid/src/threads.rs
+++ b/hypocloid/src/threads.rs
@@ -27,10 +27,9 @@ impl Threads {
         let db = Arc::new(notmuch::Database::open(&db, notmuch::DatabaseMode::ReadOnly).unwrap());
 
         let formatted = &percent_decode_str(&q).decode_utf8();
-
         debug!("threads query: {}..", formatted.as_ref().unwrap());
         let query =
-            Arc::new(notmuch::Query::create(db.clone(), &("thread:".to_owned()+&formatted.as_ref().unwrap())).unwrap());
+            Arc::new(notmuch::Query::create(db.clone(), &formatted.as_ref().unwrap()).unwrap());
 
         let threads =
             <notmuch::Query<'static> as notmuch::QueryExt>::search_threads(query.clone()).unwrap();


### PR DESCRIPTION
I'm not so sure about the design of this endpoint, so feel free to suggest doing it differently.

This currently works like `curl -X POST http://localhost:8088/messages/thread:00000000000189d8  -d '-inbox'`, meaning it uses the same endpoint as when fetching a thread, but instead of GET it uses POST, and the request body is in the same format `notmuch tag` expects.

I wasn't sure how to do this with `notmuch-rs` so I relied on the notmuch cli tool, like the original `/messages/*` endpoint does.