### PR TITLE
add a --allow-cors flag to hypocloid that allows `http://localhost:3000`

### DIFF
--- a/hypocloid/Cargo.lock
+++ b/hypocloid/Cargo.lock
@@ -24,6 +24,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
+name = "argh"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f023c76cd7975f9969f8e29f0e461decbdc7f51048ce43427107a3d192f1c9bf"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ad219abc0c06ca788aface2e3a1970587e3413ab70acd20e54b6ec524c1f8f"
+dependencies = [
+ "argh_shared",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38de00daab4eac7d753e97697066238d67ce9d7e2d823ab4f72fe14af29f3f33"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +380,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +466,7 @@ name = "hypocloid"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argh",
  "bytes",
  "dirs",
  "env_logger",
@@ -1211,6 +1250,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-xid"

--- a/hypocloid/Cargo.toml
+++ b/hypocloid/Cargo.toml
@@ -18,6 +18,7 @@ serde_derive = "*"
 serde_json = "*"
 warp = "*"
 percent-encoding = "2.1.0"
+argh = "*"
 
 [dependencies.tokio]
 features = ["full"]

--- a/hypocloid/src/main.rs
+++ b/hypocloid/src/main.rs
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
             Method::GET,
             Method::POST,
             Method::DELETE,
-        ]);
+        ]).allow_headers(vec!["Content-Type"]);
 
         let api = messages
             .or(threads)

--- a/hypocloid/src/main.rs
+++ b/hypocloid/src/main.rs
@@ -5,8 +5,9 @@
 extern crate log;
 
 use env_logger::Env;
+use std::env;
 use std::sync::Arc;
-use warp::Filter;
+use warp::{http::Method, Filter};
 
 /* internal modules */
 mod messages;
@@ -29,13 +30,30 @@ async fn main() -> anyhow::Result<()> {
     let messages = messages::filters::messages(state.clone());
     let tags = tags::filters::all(state.clone());
 
-    let api = messages
-        .or(threads)
-        .or(tags)
-        .with(warp::log("hypocloid::api"));
+    let args: Vec<String> = env::args().collect();
+    let cors = warp::cors()
+        .allow_origin("http://localhost:3000")
+        .allow_methods(&[Method::GET, Method::POST, Method::DELETE]);
+    let mut is_cors = false;
 
-    info!("Listening on 127.0.0.1:8088");
-    warp::serve(api).run(([127, 0, 0, 1], 8088)).await;
+    if args.iter().any(|i| i == "--allow-cors") {
+        is_cors = true;
+    }
 
+    if is_cors {
+        let api = messages
+            .or(threads)
+            .or(tags)
+            .with(cors)
+            .with(warp::log("hypocloid::api"));
+        info!("Listening on 127.0.0.1:8088, CORS enabled");
+        warp::serve(api).run(([127, 0, 0, 1], 8088)).await;
+    } else {
+        let api = messages
+            .or(threads)
+            .or(tags)
+            .with(warp::log("hypocloid::api"));
+        warp::serve(api).run(([127, 0, 0, 1], 8088)).await;
+    }
     Ok(())
 }


### PR DESCRIPTION
**This is still WIP!**

I think many people, including myself, would prefer loading the frontend in the browser. Without setting CORS headers, the browser currently blocks the responses and the UI doesn't function.

This `--allow-cors` flag makes loading the interface in the browser easier. It's currently hard-coded to allow `http://localhost:3000`.

I don't like the fact that the there's a big piece of code that is repeated, but I couldn't find how to avoid it and use `.with(cors)` only if `is_cors` is true.

I also think we should make the host configurable, but wanted to know what you think first about this whole PR before I continue :)